### PR TITLE
Adding summarised auth documentation and response examples

### DIFF
--- a/api_integrations/outdoor_temperature_viessmann/features_list_response.json
+++ b/api_integrations/outdoor_temperature_viessmann/features_list_response.json
@@ -1,0 +1,3122 @@
+{
+    "data": [
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.frostprotection",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.frostprotection",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.sensors.temperature.supply",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.sensors.temperature.supply",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.normal",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.normal",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.active",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.modes.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.modes.standby",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.modes.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.modes.active",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0.2,
+                        0.5,
+                        0.3,
+                        0.4,
+                        0.4,
+                        0.3,
+                        0.6,
+                        0.5
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        1.4,
+                        2.6999999999999997,
+                        2.7,
+                        2.3000000000000007,
+                        2.1,
+                        1.6000000000000003
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        3.7,
+                        9.3,
+                        9,
+                        11.9,
+                        14.9,
+                        7.8,
+                        11.9,
+                        13.5,
+                        11,
+                        10.5,
+                        10.3,
+                        9.2,
+                        10.6
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        82.1,
+                        98.5
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.gas.consumption.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.gas.consumption.dhw",
+            "timestamp": "2023-08-10T07:20:58.379Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.heating.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.heating.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.forcedLastFromSchedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.forcedLastFromSchedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.modes.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.modes.heating",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.temperature",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.temperature",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "standby"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.active",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.comfort",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.comfort",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 22,
+                    "unit": "celsius",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "activate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/activate",
+                    "name": "activate",
+                    "isExecutable": false,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": false,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.comfort/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.comfort",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.comfort",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "hours": {
+                    "type": "number",
+                    "value": 4699,
+                    "unit": "hour"
+                },
+                "starts": {
+                    "type": "number",
+                    "value": 22103,
+                    "unit": ""
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.burners.0.statistics",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.burners.0.statistics",
+            "timestamp": "2023-08-10T05:35:26.156Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.zone.mode",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.zone.mode",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.circulation.pump",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.circulation.pump",
+            "timestamp": "2023-08-10T05:41:32.712Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.reduced",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.reduced",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": "standby",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setMode": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.modes.active/commands/setMode",
+                    "name": "setMode",
+                    "isExecutable": true,
+                    "params": {
+                        "mode": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "heating",
+                                    "standby"
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.modes.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.modes.active",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.solar.sensors.temperature.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.solar.sensors.temperature.dhw",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "enabled": {
+                    "value": [
+                        "0"
+                    ],
+                    "type": "array"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                },
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "liter"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.sensors.volumetricFlow.allengra",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.sensors.volumetricFlow.allengra",
+            "timestamp": "2023-08-10T05:41:57.446Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.active",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.frostprotection",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.frostprotection",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.frostprotection",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.frostprotection",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.modes.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.modes.heating",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        0.30000000000000004,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        1.1,
+                        3.7,
+                        3.5,
+                        16.4,
+                        25.5,
+                        31.8,
+                        30.1,
+                        32.8,
+                        34.7,
+                        31.3,
+                        26.7,
+                        13.9,
+                        3.5
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        145.2,
+                        147.9
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-09T18:04:49.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.power.consumption.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.power.consumption.heating",
+            "timestamp": "2023-08-10T03:29:08.607Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.sensors.temperature.room",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.sensors.temperature.room",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.burners.0",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.burners.0",
+            "timestamp": "2023-08-10T05:40:43.025Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "name": {
+                    "value": "",
+                    "type": "string"
+                },
+                "type": {
+                    "value": "heatingCircuit",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 20
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "reason": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "demand": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.reducedEnergySaving",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.reducedEnergySaving",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 25.3,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.boiler.sensors.temperature.commonSupply",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.boiler.sensors.temperature.commonSupply",
+            "timestamp": "2023-08-10T12:44:48.344Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.operating.modes.off",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.operating.modes.off",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "kilowattHour"
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "value": 0.1,
+                    "unit": "kilowattHour"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 0.2,
+                    "unit": "kilowattHour"
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "value": 0.7,
+                    "unit": "kilowattHour"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 5.5,
+                    "unit": "kilowattHour"
+                },
+                "lastYear": {
+                    "type": "number",
+                    "value": 6.6,
+                    "unit": "kilowattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.power.consumption.summary.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.power.consumption.summary.dhw",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [],
+                        "tue": [],
+                        "wed": [],
+                        "thu": [],
+                        "fri": [],
+                        "sat": [],
+                        "sun": []
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.pumps.circulation.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "on"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "off",
+                                "overlapAllowed": false
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.pumps.circulation.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.pumps.circulation.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.solar",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.solar",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.forcedLastFromSchedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.forcedLastFromSchedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.active",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "reason": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "demand": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.reducedEnergySaving",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.reducedEnergySaving",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "normal",
+                                "start": "07:00",
+                                "end": "21:00",
+                                "position": 0
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.heating.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "normal",
+                                    "comfort"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "reduced",
+                                "overlapAllowed": false
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.heating.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.heating.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        52,
+                        159.6,
+                        238.2,
+                        254,
+                        275.6,
+                        333.8,
+                        239.3,
+                        142.1,
+                        52.9,
+                        0
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        979.6,
+                        919.9
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-07T20:17:48.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-07T20:17:54.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-07T20:17:48.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-07T20:17:48.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.gas.consumption.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.gas.consumption.heating",
+            "timestamp": "2023-08-09T21:45:54.309Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.circulation.pump",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.circulation.pump",
+            "timestamp": "2023-08-10T05:41:32.712Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.temperature.hygiene",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.temperature.hygiene",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 21,
+                    "unit": "celsius",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.normal/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.normal",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.normal",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 0.2,
+                    "unit": "cubicMeter"
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "value": 2.7,
+                    "unit": "cubicMeter"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 3.7,
+                    "unit": "cubicMeter"
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "value": 9.3,
+                    "unit": "cubicMeter"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 82.1,
+                    "unit": "cubicMeter"
+                },
+                "lastYear": {
+                    "type": "number",
+                    "value": 98.5,
+                    "unit": "cubicMeter"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.gas.consumption.summary.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.gas.consumption.summary.dhw",
+            "timestamp": "2023-08-10T07:20:58.379Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.solar.pumps.circuit",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.solar.pumps.circuit",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "commands": {
+                "setCurve": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve",
+                    "name": "setCurve",
+                    "isExecutable": true,
+                    "params": {
+                        "slope": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 0.2,
+                                "max": 3.5,
+                                "stepping": 0.1
+                            }
+                        },
+                        "shift": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": -13,
+                                "max": 40,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.heating.curve",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.heating.curve",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.hygiene.trigger",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.hygiene.trigger",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "commands": {
+                "setCurve": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.heating.curve/commands/setCurve",
+                    "name": "setCurve",
+                    "isExecutable": true,
+                    "params": {
+                        "slope": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 0.2,
+                                "max": 3.5,
+                                "stepping": 0.1
+                            }
+                        },
+                        "shift": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": -13,
+                                "max": 40,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.heating.curve",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.heating.curve",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.modes.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.modes.heating",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.modes.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.modes.standby",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "7956291101464122"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/device.serial",
+            "gatewayId": "7724827140474216",
+            "feature": "device.serial",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        0.30000000000000004,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        1.3,
+                        4.4,
+                        4.1,
+                        17.099999999999998,
+                        26.4,
+                        32.4,
+                        30.8,
+                        33.599999999999994,
+                        35.400000000000006,
+                        32,
+                        27.4,
+                        14.5,
+                        4.2
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        150.7,
+                        154.5
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-09T18:04:49.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T03:28:54.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.power.consumption.total",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.power.consumption.total",
+            "timestamp": "2023-08-10T03:29:08.607Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.sensors.temperature.room",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.sensors.temperature.room",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": 43,
+                    "unit": "celsius",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTargetTemperature": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.temperature.main/commands/setTargetTemperature",
+                    "name": "setTargetTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "temperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 10,
+                                "efficientLowerBorder": 10,
+                                "efficientUpperBorder": 60,
+                                "max": 60,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.temperature.main",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.temperature.main",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "value": "balanced",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "setMode": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.operating.modes.active/commands/setMode",
+                    "name": "setMode",
+                    "isExecutable": true,
+                    "params": {
+                        "mode": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "enum": [
+                                    "balanced",
+                                    "off"
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.operating.modes.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.operating.modes.active",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "cubicMeter"
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "cubicMeter"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "cubicMeter"
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "cubicMeter"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 979.6,
+                    "unit": "cubicMeter"
+                },
+                "lastYear": {
+                    "type": "number",
+                    "value": 919.9,
+                    "unit": "cubicMeter"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.gas.consumption.summary.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.gas.consumption.summary.heating",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 21.5,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.sensors.temperature.outside",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.sensors.temperature.outside",
+            "timestamp": "2023-08-10T12:46:17.929Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.pumps.circulation",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.pumps.circulation",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.reduced",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.reduced",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "commands": {
+                "setCurve": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.heating.curve/commands/setCurve",
+                    "name": "setCurve",
+                    "isExecutable": true,
+                    "params": {
+                        "slope": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 0.2,
+                                "max": 3.5,
+                                "stepping": 0.1
+                            }
+                        },
+                        "shift": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": -13,
+                                "max": 40,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.heating.curve",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.heating.curve",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "enabled": {
+                    "type": "array",
+                    "value": [
+                        "0"
+                    ]
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.burners",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.burners",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.forcedLastFromSchedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.forcedLastFromSchedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "shift": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 0
+                },
+                "slope": {
+                    "type": "number",
+                    "unit": "",
+                    "value": 1.4
+                }
+            },
+            "commands": {
+                "setCurve": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.heating.curve/commands/setCurve",
+                    "name": "setCurve",
+                    "isExecutable": true,
+                    "params": {
+                        "slope": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 0.2,
+                                "max": 3.5,
+                                "stepping": 0.1
+                            }
+                        },
+                        "shift": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": -13,
+                                "max": 40,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.heating.curve",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.heating.curve",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.standby",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/activate",
+                    "name": "activate",
+                    "isExecutable": false,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.forcedLastFromSchedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.forcedLastFromSchedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.heating.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.heating.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.sensors.temperature.supply",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.sensors.temperature.supply",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "percent"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.burners.0.modulation",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.burners.0.modulation",
+            "timestamp": "2023-08-10T05:40:43.025Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.zone.mode",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.zone.mode",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.circulation.pump",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.circulation.pump",
+            "timestamp": "2023-08-10T05:41:32.712Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 29.5,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.sensors.temperature.outlet",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.sensors.temperature.outlet",
+            "timestamp": "2023-08-10T12:53:57.548Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "value": "off"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.frostprotection",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.frostprotection",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.modes.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.modes.active",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.summerEco",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.summerEco",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.sensors.temperature.supply",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.sensors.temperature.supply",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.comfort",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.comfort",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.modes.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.modes.standby",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.oneTimeCharge/commands/activate",
+                    "name": "activate",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "deactivate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.oneTimeCharge/commands/deactivate",
+                    "name": "deactivate",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.oneTimeCharge",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.oneTimeCharge",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.temperature",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.temperature",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "reason": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "demand": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.reducedEnergySaving",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.reducedEnergySaving",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "changeEndDate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holiday/commands/changeEndDate",
+                    "name": "changeEndDate",
+                    "isExecutable": false,
+                    "params": {
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": true
+                            }
+                        }
+                    }
+                },
+                "schedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holiday/commands/schedule",
+                    "name": "schedule",
+                    "isExecutable": true,
+                    "params": {
+                        "start": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                            }
+                        },
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": true
+                            }
+                        }
+                    }
+                },
+                "unschedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holiday/commands/unschedule",
+                    "name": "unschedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holiday",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.operating.programs.holiday",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.modes.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.modes.standby",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0.2,
+                        0.5,
+                        0.3,
+                        0.4,
+                        0.4,
+                        0.3,
+                        0.6,
+                        0.5
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        1.4,
+                        2.6999999999999997,
+                        2.7,
+                        2.3000000000000007,
+                        2.1,
+                        1.6000000000000003
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        3.7,
+                        9.3,
+                        9,
+                        63.9,
+                        174.5,
+                        246,
+                        265.9,
+                        289.1,
+                        344.8,
+                        249.8,
+                        152.4,
+                        62.099999999999994,
+                        10.6
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        1061.7,
+                        1018.4
+                    ],
+                    "unit": "cubicMeter"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-10T05:38:55.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.gas.consumption.total",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.gas.consumption.total",
+            "timestamp": "2023-08-10T07:20:58.380Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "currentDay": {
+                    "type": "number",
+                    "value": 0,
+                    "unit": "kilowattHour"
+                },
+                "lastSevenDays": {
+                    "type": "number",
+                    "value": 0.7,
+                    "unit": "kilowattHour"
+                },
+                "currentMonth": {
+                    "type": "number",
+                    "value": 1.1,
+                    "unit": "kilowattHour"
+                },
+                "lastMonth": {
+                    "type": "number",
+                    "value": 3.7,
+                    "unit": "kilowattHour"
+                },
+                "currentYear": {
+                    "type": "number",
+                    "value": 145.2,
+                    "unit": "kilowattHour"
+                },
+                "lastYear": {
+                    "type": "number",
+                    "value": 147.9,
+                    "unit": "kilowattHour"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.power.consumption.summary.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.power.consumption.summary.heating",
+            "timestamp": "2023-08-10T03:29:08.607Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.circulation.pump",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.circulation.pump",
+            "timestamp": "2023-08-10T05:41:32.712Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.zone.mode",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.zone.mode",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.standby",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "week": {
+                    "type": "array",
+                    "value": [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "month": {
+                    "type": "array",
+                    "value": [
+                        0.2,
+                        0.7,
+                        0.6,
+                        0.7,
+                        0.9,
+                        0.6,
+                        0.7,
+                        0.8,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.6,
+                        0.7
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "year": {
+                    "type": "array",
+                    "value": [
+                        5.5,
+                        6.6
+                    ],
+                    "unit": "kilowattHour"
+                },
+                "dayValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-08T17:12:43.000Z"
+                },
+                "weekValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-07T20:17:54.000Z"
+                },
+                "monthValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-08T17:12:43.000Z"
+                },
+                "yearValueReadAt": {
+                    "type": "string",
+                    "value": "2023-08-08T17:12:43.000Z"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.power.consumption.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.power.consumption.dhw",
+            "timestamp": "2023-08-09T21:45:54.309Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.normal",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.normal",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "demand": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "temperature": {
+                    "value": 21,
+                    "unit": "celsius",
+                    "type": "number"
+                }
+            },
+            "commands": {
+                "setTemperature": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.reduced/commands/setTemperature",
+                    "name": "setTemperature",
+                    "isExecutable": true,
+                    "params": {
+                        "targetTemperature": {
+                            "type": "number",
+                            "required": true,
+                            "constraints": {
+                                "min": 3,
+                                "max": 37,
+                                "stepping": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.reduced",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.reduced",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "start": {
+                    "value": "",
+                    "type": "string"
+                },
+                "end": {
+                    "value": "",
+                    "type": "string"
+                }
+            },
+            "commands": {
+                "changeEndDate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holidayAtHome/commands/changeEndDate",
+                    "name": "changeEndDate",
+                    "isExecutable": false,
+                    "params": {
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": true
+                            }
+                        }
+                    }
+                },
+                "schedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holidayAtHome/commands/schedule",
+                    "name": "schedule",
+                    "isExecutable": true,
+                    "params": {
+                        "start": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$"
+                            }
+                        },
+                        "end": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "regEx": "^[\\d]{4}-[\\d]{2}-[\\d]{2}$",
+                                "sameDayAllowed": true
+                            }
+                        }
+                    }
+                },
+                "unschedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holidayAtHome/commands/unschedule",
+                    "name": "unschedule",
+                    "isExecutable": true,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.operating.programs.holidayAtHome",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.operating.programs.holidayAtHome",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.standby",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "value": "7956291101464122"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.boiler.serial",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.boiler.serial",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.standby",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.standby",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.temperature",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.temperature",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.sensors.temperature.room",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.sensors.temperature.room",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.modes.heating",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.modes.heating",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 25.8,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.sensors.temperature.supply",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.sensors.temperature.supply",
+            "timestamp": "2023-08-10T12:18:06.346Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": true,
+                    "type": "boolean"
+                },
+                "entries": {
+                    "value": {
+                        "mon": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "tue": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "wed": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "thu": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "fri": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "sat": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ],
+                        "sun": [
+                            {
+                                "mode": "on",
+                                "start": "07:30",
+                                "end": "22:30",
+                                "position": 0
+                            }
+                        ]
+                    },
+                    "type": "Schedule"
+                }
+            },
+            "commands": {
+                "setSchedule": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.schedule/commands/setSchedule",
+                    "name": "setSchedule",
+                    "isExecutable": true,
+                    "params": {
+                        "newSchedule": {
+                            "type": "Schedule",
+                            "required": true,
+                            "constraints": {
+                                "modes": [
+                                    "on"
+                                ],
+                                "maxEntries": 4,
+                                "resolution": 10,
+                                "defaultMode": "off",
+                                "overlapAllowed": false
+                            }
+                        }
+                    }
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.temperature",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.temperature",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.solar.sensors.temperature.collector",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.solar.sensors.temperature.collector",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.operating.modes.balanced",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.operating.modes.balanced",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": true
+                },
+                "status": {
+                    "type": "string",
+                    "value": "on"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.solar.power.production",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.solar.power.production",
+            "timestamp": "2023-08-09T21:45:54.309Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.programs.summerEco",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.programs.summerEco",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.sensors.temperature.hydraulicSeparator",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.sensors.temperature.hydraulicSeparator",
+            "timestamp": "2023-08-09T11:13:59.478Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.heating.schedule",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.heating.schedule",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.reduced",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.reduced",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.normal",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.normal",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.zone.mode",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.zone.mode",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.operating.programs.summerEco",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.operating.programs.summerEco",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "value": []
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/device.messages.errors.raw",
+            "gatewayId": "7724827140474216",
+            "feature": "device.messages.errors.raw",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "enabled": {
+                    "value": false,
+                    "type": "boolean"
+                }
+            },
+            "commands": {
+                "activate": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.hygiene/commands/activate",
+                    "name": "activate",
+                    "isExecutable": false,
+                    "params": {}
+                },
+                "enable": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.hygiene/commands/enable",
+                    "name": "enable",
+                    "isExecutable": true,
+                    "params": {}
+                },
+                "disable": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.hygiene/commands/disable",
+                    "name": "disable",
+                    "isExecutable": false,
+                    "params": {}
+                }
+            },
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.hygiene",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.hygiene",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.operating.programs.comfort",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.2.operating.programs.comfort",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.sensors.temperature.room",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.0.sensors.temperature.room",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 15,
+                    "unit": "celsius"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.boiler.temperature",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.boiler.temperature",
+            "timestamp": "2023-08-09T11:13:59.476Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {},
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.operating.modes.active",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.1.operating.modes.active",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": false,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "value": false
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.summerEco",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.summerEco",
+            "timestamp": "2023-08-09T11:13:59.477Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "value": 39.8,
+                    "unit": "celsius"
+                },
+                "status": {
+                    "type": "string",
+                    "value": "connected"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.dhw.sensors.temperature.hotWaterStorage",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.dhw.sensors.temperature.hotWaterStorage",
+            "timestamp": "2023-08-10T12:43:32.566Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "properties": {
+                "active": {
+                    "value": false,
+                    "type": "boolean"
+                },
+                "reason": {
+                    "value": "unknown",
+                    "type": "string"
+                },
+                "demand": {
+                    "value": "heating",
+                    "type": "string"
+                }
+            },
+            "commands": {},
+            "apiVersion": 1,
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.operating.programs.reducedEnergySaving",
+            "gatewayId": "7724827140474216",
+            "feature": "heating.circuits.3.operating.programs.reducedEnergySaving",
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "isEnabled": true,
+            "isReady": true,
+            "deviceId": "0"
+        },
+        {
+            "apiVersion": 1,
+            "isEnabled": true,
+            "isReady": true,
+            "timestamp": "2023-08-08T07:08:11.578Z",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.name",
+            "feature": "heating.circuits.0.name",
+            "deviceId": "0",
+            "gatewayId": "7724827140474216",
+            "components": [],
+            "commands": {
+                "setName": {
+                    "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.0.name/commands/setName",
+                    "name": "setName",
+                    "isExecutable": true,
+                    "params": {
+                        "name": {
+                            "type": "string",
+                            "required": true,
+                            "constraints": {
+                                "minLength": 1,
+                                "maxLength": 20
+                            }
+                        }
+                    }
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "value": ""
+                }
+            }
+        },
+        {
+            "apiVersion": 1,
+            "isEnabled": false,
+            "isReady": true,
+            "gatewayId": "7724827140474216",
+            "timestamp": "2022-04-07T12:41:12.194Z",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.1.name",
+            "feature": "heating.circuits.1.name",
+            "components": [],
+            "deviceId": "0",
+            "commands": {},
+            "properties": {}
+        },
+        {
+            "apiVersion": 1,
+            "isEnabled": false,
+            "isReady": true,
+            "gatewayId": "7724827140474216",
+            "timestamp": "2022-04-07T12:41:12.196Z",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.2.name",
+            "feature": "heating.circuits.2.name",
+            "components": [],
+            "deviceId": "0",
+            "commands": {},
+            "properties": {}
+        },
+        {
+            "apiVersion": 1,
+            "isEnabled": false,
+            "isReady": true,
+            "gatewayId": "7724827140474216",
+            "timestamp": "2022-04-07T12:41:12.198Z",
+            "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.circuits.3.name",
+            "feature": "heating.circuits.3.name",
+            "components": [],
+            "deviceId": "0",
+            "commands": {},
+            "properties": {}
+        }
+    ]
+}

--- a/api_integrations/outdoor_temperature_viessmann/temperature.go
+++ b/api_integrations/outdoor_temperature_viessmann/temperature.go
@@ -1,5 +1,9 @@
 package temperature
 
+import "github.com/joho/godotenv"
+
 func Outdoor() {
+	godotenv.Load(".env")
+
 	// fmt.Print("It's freaking cold outside!")
 }

--- a/api_integrations/outdoor_temperature_viessmann/temperature_response_example.json
+++ b/api_integrations/outdoor_temperature_viessmann/temperature_response_example.json
@@ -1,0 +1,24 @@
+{
+    "data": {
+        "properties": {
+            "value": {
+                "type": "number",
+                "value": 21,
+                "unit": "celsius"
+            },
+            "status": {
+                "type": "string",
+                "value": "connected"
+            }
+        },
+        "commands": {},
+        "apiVersion": 1,
+        "uri": "https://api.viessmann.com/iot/v2/features/installations/1986695/gateways/7724827140474216/devices/0/features/heating.sensors.temperature.outside",
+        "gatewayId": "7724827140474216",
+        "feature": "heating.sensors.temperature.outside",
+        "timestamp": "2023-08-10T12:32:36.196Z",
+        "isEnabled": true,
+        "isReady": true,
+        "deviceId": "0"
+    }
+}

--- a/development_notes/viessmann_integration.md
+++ b/development_notes/viessmann_integration.md
@@ -11,3 +11,32 @@ Free basic package: 1450 API calls per day, 1 active client, limited feature ava
 
 [Data Points](https://documentation.viessmann.com/static/iot/data-points)  
 \- overview of available data points depending on subscription
+
+
+
+## Notes from first auth attempt
+
+Switch from corporate to personal Postman account
+
+There is a [public collection](https://www.postman.com/vimicho/workspace/viessmann-api-public/collection/12055031-17157e90-a2e8-47b6-a7b8-2320c2941db3?action=share&creator=12055031) with prepared requests available for Postman
+
+1st request in browser 'Authorization request'
+  requires code challenge
+  scope param: 'IoTUser offline_access'
+
+  returns code TTL 20 seconds!
+
+2nd request via Postman 'Authorization code exchange'
+  requires response code from step one
+  requires code verifier
+
+  returns Bearer token TTL 3600 seconds
+  returns refresh_token (if scope in step one includes 'offline_access') TTL 180 days / 15552000 seconds
+
+3rd request 'Authorization code exchange'
+  requires refresh token
+
+## Notes from first data request
+
+Need to pass installation ID, gateway serial and device ID with the request. Don't forget the Bearer token for Authorization.
+https://api.viessmann.com/iot/v2/features/installations/INSTALLATION_ID/gateways/GATEWAY_SERIAL/devices/DEVICE_ID/features/heating.sensors.temperature.outside


### PR DESCRIPTION
After successful authorisation this commit adds notes how to authorise for the Viessmann API. It also adds responses of the /features request and an example of a specific /features/.. request.